### PR TITLE
Allow custom scrape configs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,6 +23,7 @@ RUN curl -L -Os https://github.com/thanos-io/thanos/releases/download/v${THANOS_
 FROM alpine:latest
 LABEL maintainer="andy.lo-a-foe@philips.com"
 RUN apk add --update supervisor jq && rm  -rf /tmp/* /var/cache/apk/*
+RUN apk add yq --repository http://dl-cdn.alpinelinux.org/alpine/edge/community
 RUN mkdir -p /sidecars/bin /sidecars/supervisor/conf.d sidecars/etc
 RUN mkdir -p /prometheus /thanos
 COPY --from=prometheus /app/prometheus /sidecars/bin
@@ -30,7 +31,9 @@ COPY --from=thanos     /app/thanos     /sidecars/bin
 COPY prometheus.yml  /sidecars/etc
 COPY prometheus.conf /sidecars/supervisor/conf.d
 COPY thanos.conf /sidecars/supervisor/conf.d
-COPY scripts/thanos_s3.sh /sidecars/bin
+COPY scripts/ /sidecars/bin
+RUN sh -c "chmod +x /sidecars/bin/thanos_s3.sh"
+RUN sh -c "chmod +x /sidecars/bin/prometheus_targets.sh"
 
 EXPOSE 9090
 

--- a/docker/Dockerfile_with_exporter
+++ b/docker/Dockerfile_with_exporter
@@ -29,6 +29,7 @@ RUN curl -L -Os https://github.com/thanos-io/thanos/releases/download/v${THANOS_
 FROM alpine:latest
 LABEL maintainer="andy.lo-a-foe@philips.com"
 RUN apk add --update supervisor jq && rm  -rf /tmp/* /var/cache/apk/*
+RUN apk add yq --repository http://dl-cdn.alpinelinux.org/alpine/edge/community
 RUN mkdir -p /sidecars/bin /sidecars/supervisor/conf.d sidecars/etc
 RUN mkdir -p /prometheus /thanos
 COPY --from=prometheus /app/prometheus /sidecars/bin
@@ -38,7 +39,9 @@ COPY prometheus.yml  /sidecars/etc
 COPY cf_exporter.conf /sidecars/supervisor/conf.d
 COPY prometheus.conf /sidecars/supervisor/conf.d
 COPY thanos.conf /sidecars/supervisor/conf.d
-COPY scripts/thanos_s3.sh /sidecars/bin
+COPY scripts/ /sidecars/bin
+RUN sh -c "chmod +x /sidecars/bin/thanos_s3.sh"
+RUN sh -c "chmod +x /sidecars/bin/prometheus_targets.sh"
 
 EXPOSE 9090
 

--- a/docker/prometheus.conf
+++ b/docker/prometheus.conf
@@ -1,5 +1,5 @@
 [program:prometheus]
-command = /sidecars/bin/prometheus --config.file=/sidecars/etc/prometheus.yml --storage.tsdb.path=/prometheus --storage.tsdb.retention=2d --storage.tsdb.min-block-duration=30m --storage.tsdb.max-block-duration=30m --web.enable-lifecycle
+command = /sidecars/bin/prometheus_targets.sh --config.file=/sidecars/etc/prometheus.yml --storage.tsdb.path=/prometheus --storage.tsdb.retention=2d --storage.tsdb.min-block-duration=30m --storage.tsdb.max-block-duration=30m --web.enable-lifecycle
 autostart = true
 autorestart = true
 startsecs = 5

--- a/docker/scripts/prometheus_targets.sh
+++ b/docker/scripts/prometheus_targets.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+set -e
+
+# Generate file to merge into actual config file
+echo $PROMETHEUS_TARGETS | base64 -d >> /sidecars/etc/configured_targets.yml
+
+# Merge the two yaml files together, overwriting prometheus.yml in place
+yq m --inplace --arrays append /sidecars/etc/prometheus.yml /sidecars/etc/configured_targets.yml
+
+# Start and run prometheus
+exec /sidecars/bin/prometheus "$@"


### PR DESCRIPTION
This change allows the prometheus scrape targets to be configured by the consumer of the module.

It does this in a similar fashion as was done for S3.
It works with base64 + yq, which means you do not need to specify the entire file, just the scrape_configs part.

- output changed, add thanos app id
- docker files changed: added yq, copied in second sh script for prometheus
- changed prometheus.conf to start the shell script instead of prometheus directly
- added script to merge the scrape-configs that are in this repo with the ones provided through the env-vars and then start prometheus

pleas note: this change is backwards compatible, if no custom scrap-configs are supplied, it will just use the file as-is, just as it does now :)